### PR TITLE
Fix HeightMap preview download image size

### DIFF
--- a/modules/ui/heightmap-editor.js
+++ b/modules/ui/heightmap-editor.js
@@ -1316,10 +1316,10 @@ function editHeightmap() {
     img.onload = function () {
       const canvas = document.createElement("canvas");
       const ctx = canvas.getContext("2d");
-      canvas.width = svgWidth;
-      canvas.height = svgHeight;
+      canvas.width = graphWidth;
+      canvas.height = graphHeight;
       document.body.insertBefore(canvas, optionsContainer);
-      ctx.drawImage(img, 0, 0, svgWidth, svgHeight);
+      ctx.drawImage(img, 0, 0, graphWidth, graphHeight);
       const imgBig = canvas.toDataURL("image/png");
       const link = document.createElement("a");
       link.download = getFileName("Heightmap") + ".png";


### PR DESCRIPTION
When the user click on the Height Map the downloaded image size doesn't match the canvas size leading to stretch version of said height map.
Using the canvas size when creating the image fix the problem